### PR TITLE
Backend refactor

### DIFF
--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -110,6 +110,7 @@ class Game:
 
     def reset_game(self):
         self.ongoing = False
+        self.players = {}
         self.game_duration = max(
             self.min_time, np.random.normal(self.average, self.std)
         )
@@ -137,7 +138,7 @@ class Game:
             return np.round(multiplicator, decimals=2)
 
     def cashout(self, ws) -> Cashout:
-        if ws in self.players:
+        if ws in self.players and not self.players[ws].cashout_record:
             mult = self.get_multiplicator()
             cashout = self.players[ws].cashout(mult)
             self.game_handler_parent.cash[ws] += cashout.gain

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -166,16 +166,17 @@ async def websocket_endpoint(websocket: WebSocket):
                 else:
                     cashout = game.cashout(websocket)
 
-                    await manager.broadcast_lobby(
-                        {
-                            "type": "cashout",
-                            "target": current_players[websocket].name,
-                            "mult": cashout.mult,
-                            "gains": cashout.gain,
-                            "cash_vaults": game.get_cash_vaults(current_players),
-                            "cashouts": game.get_cashouts(),
-                        }
-                    )
+                    if cashout:
+                        await manager.broadcast_lobby(
+                            {
+                                "type": "cashout",
+                                "target": current_players[websocket].name,
+                                "mult": cashout.mult,
+                                "gains": cashout.gain,
+                                "cash_vaults": game.get_cash_vaults(current_players),
+                                "cashouts": game.get_cashouts(),
+                            }
+                        )
 
     except WebSocketDisconnect:
 

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -130,7 +130,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     {
                         "type": "join",
                         "target": name,
-                        "lobby": list(current_players.values()),
+                        "lobby": [player.name for player in current_players.values()],
                         "cash_vaults": game.get_cash_vaults(current_players),
                         "bids": game.get_bids(current_players),
                         "state": "waiting" if game.is_waiting() else "playing",
@@ -151,7 +151,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     await manager.broadcast_lobby(
                         {
                             "type": "bid",
-                            "target": current_players[websocket],
+                            "target": current_players[websocket].name,
                             "amount": amount,
                             "bids": game.get_bids(current_players),
                             "cash_vaults": game.get_cash_vaults(current_players),
@@ -164,15 +164,16 @@ async def websocket_endpoint(websocket: WebSocket):
                         {"type": "error", "message": "Game has not started."}, websocket
                     )
                 else:
-                    gains = game.cashout(websocket)
+                    cashout = game.cashout(websocket)
 
                     await manager.broadcast_lobby(
                         {
                             "type": "cashout",
-                            "target": current_players[websocket],
-                            "mult": game.get_multiplicator(),
-                            "gains": gains,
+                            "target": current_players[websocket].name,
+                            "mult": cashout.mult,
+                            "gains": cashout.gain,
                             "cash_vaults": game.get_cash_vaults(current_players),
+                            "cashouts": game.get_cashouts(),
                         }
                     )
 

--- a/backend/src/crash/player.py
+++ b/backend/src/crash/player.py
@@ -1,0 +1,30 @@
+from crash.records import Cashout
+from typing import Optional
+
+
+class PlayingPlayer:
+    def __init__(self, name: str):
+        self.name = name
+        self.bid_value: int = -1
+        self.has_bid: bool = False
+        self.cashout_record: Optional[Cashout] = None
+
+    def cashout(self, mult: float) -> Cashout:
+        assert (
+            self.bid_value > 0
+        ), f"Player is cashing out when they haven't bid (bid = {self.bid})"
+        self.cashout_record = Cashout(mult, self.bid_value * mult)
+        return self.cashout_record
+
+    def bid(self, amount: int) -> bool:
+        if amount > 0 and not self.has_bid:
+            self.bid_value = amount
+            self.has_bid = True
+            return True
+        return False
+
+
+class Player:
+    def __init__(self, name: str, cash: int):
+        self.name = name
+        self.cash = cash

--- a/backend/src/crash/records.py
+++ b/backend/src/crash/records.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Cashout:
+    mult: float
+    gain: float
+
+
+@dataclass
+class CashoutMessage:
+    cashout: Cashout
+    bid: int

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     image: backend
     build:
       context: backend
-      # target: production
+    stop_grace_period: 1s
     ports:
       - "0.0.0.0:8000:8000"
   db:


### PR DESCRIPTION
This original goal of this commit was to return the full state of the cashout and bids for a given game when a player cashes out. This was unfortunately non-trivial given the current organization of the backend. I've refactored things a bit to better suit this task, and hopefully other ones later on.

The rough idea of the refactor is to have a single dict in the game class to handle the player tracking. The mapping is now WebSocket -> PlayingPlayer. The PlayingPlayer instances track name, bids, cashout mult and cashout gain.