### PR TITLE
Event based backend

### DIFF
--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -8,7 +8,7 @@ from crash.player import PlayingPlayer, Player
 from crash.records import Cashout, CashoutMessage
 from crash.utils import sleep_and_go
 
-GAME_WAIT_TIME_S = 10
+GAME_WAIT_TIME_S = 4
 
 
 class GameHandler:
@@ -201,6 +201,9 @@ class Game:
         self.crash_event.clear()
         time.sleep(self.game_duration)
         self.crash_event.set()
+
+    def get_crash_event(self):
+        return self.crash_event
 
     def wait_for_crash(self):
         self.crash_event.wait()

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -8,7 +8,7 @@ from crash.player import PlayingPlayer, Player
 from crash.records import Cashout, CashoutMessage
 from crash.utils import sleep_and_go
 
-GAME_WAIT_TIME_S = 4
+GAME_WAIT_TIME_S = 10
 
 
 class GameHandler:

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -116,13 +116,14 @@ class Game:
             return False
 
     def blocking_pre_game_wait(self):
-        self.start_event.clear()
-        Thread(target=lambda: sleep_and_go(GAME_WAIT_TIME_S, self.start_event)).start()
+        sleep_and_go(GAME_WAIT_TIME_S, self.start_event)
         self.start_event.wait()
 
     def reset_game(self):
         self.ongoing = False
         self.players = {}
+        self.crash_event.clear()
+        self.start_event.clear()
         self.game_duration = max(
             self.min_time, np.random.normal(self.average, self.std)
         )
@@ -198,9 +199,7 @@ class Game:
             return False  # Game is not crashed, it has not started
 
     def launch_crash_timer(self):
-        self.crash_event.clear()
-        time.sleep(self.game_duration)
-        self.crash_event.set()
+        sleep_and_go(self.game_duration, self.crash_event)
 
     def get_crash_event(self):
         return self.crash_event

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -96,7 +96,6 @@ def run_async_loop():
     event_loop.run_until_complete(loop())
 
 
-# thread = Thread(target = loop)
 thread = Thread(target=run_async_loop, daemon=True)
 thread.start()
 

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -89,9 +89,6 @@ async def loop():
         # next time a player joins an empty lobby
         player_join_event.clear()
 
-        # TODO: remove sleep and make loop loose by using events
-        time.sleep(0.02)
-
 
 def run_async_loop():
     event_loop = asyncio.new_event_loop()

--- a/backend/src/crash/utils.py
+++ b/backend/src/crash/utils.py
@@ -1,12 +1,16 @@
 import time
 import asyncio
-from threading import Event
+from threading import Event, Thread
 
 
 def sleep_and_go(duration: int, event: Event):
     """Sleep for `duration` s, then fire the `event`"""
-    time.sleep(duration)
-    event.set()
+
+    def _thread_func():
+        time.sleep(duration)
+        event.set()
+
+    Thread(target=_thread_func).start()
 
 
 def run_async_in_thread(async_func):

--- a/backend/src/crash/utils.py
+++ b/backend/src/crash/utils.py
@@ -5,7 +5,7 @@ from threading import Event
 
 def sleep_and_go(duration: int, event: Event):
     """Sleep for `duration` s, then fire the `event`"""
-    time.sleep(duration / 1000.0)
+    time.sleep(duration)
     event.set()
 
 

--- a/backend/src/crash/utils.py
+++ b/backend/src/crash/utils.py
@@ -1,0 +1,16 @@
+import time
+import asyncio
+from threading import Event
+
+
+def sleep_and_go(duration: int, event: Event):
+    """Sleep for `duration` s, then fire the `event`"""
+    time.sleep(duration / 1000.0)
+    event.set()
+
+
+def run_async_in_thread(async_func):
+    # Create a new event loop in the thread and run the async function
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(async_func())


### PR DESCRIPTION
Clean up main loop by using event-based logic:
```
if len(current_players) == 0:
    print("Waiting for players...")
    player_join_event.wait()

# Start timer
await manager.broadcast_lobby({"type": "state", "state": "waiting"})
game.blocking_pre_game_wait()

# Start the game
game.start_game()
await manager.broadcast_lobby({"type": "state", "state": "playing"})

# Send the multiplicator to be drawn
sender = Thread(
    target=run_async_in_thread,
    args=(lambda: continuously_transmit_mult(game.get_crash_event()),),
)
sender.start()

# Play until crash
game.wait_for_crash()
await manager.broadcast_lobby({"type": "state", "state": "crashed"})
game.reset_game()

# Clear the event so that we can set it again
# next time a player joins an empty lobby
player_join_event.clear()
```

Also fixed concurrent memory access error:
```
Exception in thread Thread-70 (run_async_in_thread):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/home/frank/crash/backend/src/crash/utils.py", line 16, in run_async_in_thread
    loop.run_until_complete(async_func())
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/frank/crash/backend/src/crash/main.py", line 45, in continuously_transmit_mult
    await manager.broadcast_lobby({"type": "mult", "mult": game.get_multiplicator()})
  File "/home/frank/crash/backend/src/crash/main.py", line 30, in broadcast_lobby
    await connection.send_text(json.dumps(message))
  File "/home/frank/crash/env/lib/python3.12/site-packages/starlette/websockets.py", line 165, in sen
d_text
    await self.send({"type": "websocket.send", "text": data})
  File "/home/frank/crash/env/lib/python3.12/site-packages/starlette/websockets.py", line 85, in send
    await self._send(message)
 [....]
  File "/home/frank/crash/env/lib/python3.12/site-packages/websockets/extensions/permessage_deflate.p
y", line 189, in encode
    assert data[-4:] == _EMPTY_UNCOMPRESSED_BLOCK
```