### PR TITLE
Asyncio + small db changes

### DIFF
--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -3,13 +3,13 @@ import time
 from typing import Optional, Dict
 from fastapi import WebSocket
 from asyncio import Lock, Event
-import asyncio, logging
+import logging
 
 from crash.player import PlayingPlayer
 from crash.records import Cashout, CashoutMessage
 from crash.utils import background_sleep_and_go
 
-GAME_WAIT_TIME_S = 3
+GAME_WAIT_TIME_S = 5
 
 
 class GameHandler:
@@ -17,8 +17,8 @@ class GameHandler:
     def __init__(
         self,
         name: str = "New Lobby",
-        average: float = 5,
-        standard_deviation: float = 1,
+        average: float = 30,
+        standard_deviation: float = 10,
         minimum_time: float = 3,
         starting_multiplicator: float = 0.75,
         multiplicator_coef: float = 0.1,
@@ -214,8 +214,6 @@ class Game:
         return self.crash_event
 
     async def wait_for_crash(self):
-        # for task in asyncio.all_tasks():
-        #     logging.info(f"[wait_for_crash] Task: {task}, Coroutine: {task.get_coro().__name__}, Done: {task.done()}")
         await self.crash_event.wait()
 
     def get_estimated_start_time(self) -> Optional[int]:
@@ -226,7 +224,6 @@ class Game:
             cashout = player.cashout_record
             # Save history only if the player has bid
             if player.has_bid:
-                logging.info(f"Adding bid of {player.bid_value} to {player.name}")
                 player.bid_history.append(player.bid_value)
                 # Checks if the player has managed to cashout before crash
                 if cashout != None:

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -2,13 +2,14 @@ import numpy as np
 import time
 from typing import Optional, Dict
 from fastapi import WebSocket
-from threading import Lock, Event, Thread
+from asyncio import Lock, Event
+import asyncio, logging
 
 from crash.player import PlayingPlayer, Player
 from crash.records import Cashout, CashoutMessage
 from crash.utils import sleep_and_go
 
-GAME_WAIT_TIME_S = 10
+GAME_WAIT_TIME_S = 3
 
 
 class GameHandler:
@@ -16,8 +17,8 @@ class GameHandler:
     def __init__(
         self,
         name: str = "New Lobby",
-        average: float = 30,
-        standard_deviation: float = 10,
+        average: float = 5,
+        standard_deviation: float = 1,
         minimum_time: float = 3,
         starting_multiplicator: float = 0.75,
         multiplicator_coef: float = 0.1,
@@ -56,8 +57,8 @@ class GameHandler:
             game_handler_parent=self,
         )
 
-    def join(self, ws, name, cash):
-        with self.mutex:
+    async def join(self, ws, name, cash):
+        async with self.mutex:
             self.players[ws] = Player(name, cash)
 
 
@@ -99,27 +100,27 @@ class Game:
             ws: PlayingPlayer(player.name) for ws, player in players.items()
         }
 
-    def start_game(self) -> bool:
+    async def start_game(self) -> bool:
         if not self.ongoing:
             self.game_duration = max(
                 self.min_time, np.random.normal(self.average, self.std)
             )
             self.ongoing = True
             self.initial_time = time.time()
-            Thread(target=self.launch_crash_timer).start()
+            await self.launch_crash_timer()
             return True
         else:
             print("Game already started.")
             return False
 
-    def start_pre_game_wait(self) -> int:
+    async def start_pre_game_wait(self) -> int:
         """Start the pre-game wait thread and return the estimated start time."""
         self.estimated_game_start_time = time.time() + GAME_WAIT_TIME_S
-        sleep_and_go(GAME_WAIT_TIME_S, self.start_event)
+        await sleep_and_go(GAME_WAIT_TIME_S, self.start_event)
         return self.estimated_game_start_time
 
-    def wait_for_game_start(self):
-        self.start_event.wait()
+    async def wait_for_game_start(self):
+        await self.start_event.wait()
 
     def reset_game(self):
         self.ongoing = False
@@ -202,32 +203,33 @@ class Game:
         else:
             return False  # Game is not crashed, it has not started
 
-    def launch_crash_timer(self):
-        sleep_and_go(self.game_duration, self.crash_event)
+    async def launch_crash_timer(self):
+        await sleep_and_go(self.game_duration, self.crash_event)
 
     def get_crash_event(self):
         return self.crash_event
 
-    def wait_for_crash(self):
-        self.crash_event.wait()
+    async def wait_for_crash(self):
+        # for task in asyncio.all_tasks():
+        #     logging.info(f"[wait_for_crash] Task: {task}, Coroutine: {task.get_coro().__name__}, Done: {task.done()}")
+        await self.crash_event.wait()
 
     def get_estimated_start_time(self) -> Optional[int]:
         return self.estimated_game_start_time
 
     def update_players_history(self):
-        for ws, player in self.players.items():
-            lobby_player = self.game_handler_parent.players[ws]
+        for player in self.players.values():
             cashout = player.cashout_record
             # Save history only if the player has bid
             if player.has_bid:
-                lobby_player.bid_history.append(player.bid_value)
+                player.bid_history.append(player.bid_value)
                 # Checks if the player has managed to cashout before crash
                 if cashout != None:
-                    lobby_player.gain_history.append(cashout.gain)
-                    lobby_player.mult_history.append(cashout.mult)
+                    player.gain_history.append(cashout.gain)
+                    player.mult_history.append(cashout.mult)
                 else:
-                    lobby_player.gain_history.append(-1 * player.bid_value)
-                    lobby_player.mult_history.append(0)
+                    player.gain_history.append(-1 * player.bid_value)
+                    player.mult_history.append(0)
 
 
 if __name__ == "__main__":

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -64,9 +64,7 @@ async def continuously_transmit_mult(stop_event: asyncio.Event):
 
 # Server loop
 async def loop():
-    logging.info("LOOP")
     while True:
-        logging.info("LOOP start")
         current_players = game_handler.players
         # logging.info(current_players)
         # If there is no player we wait for one to save CPU cycles
@@ -76,7 +74,6 @@ async def loop():
 
         # Start timer
         estimated_start_time = await game.start_pre_game_wait()
-        logging.info("waited for pre game wait")
         await manager.broadcast_lobby(
             {
                 "type": "state",
@@ -85,19 +82,12 @@ async def loop():
             }
         )
         await game.wait_for_game_start()
-        logging.info("waited for game start")
 
         # Start the game
         await game.start_game()
         await manager.broadcast_lobby({"type": "state", "state": "playing"})
-        logging.info("waited for game playing event message")
-        # for task in asyncio.all_tasks():
-        #     logging.info(f"[main] Task: {task}, Coroutine: {task.get_coro().__name__}, Done: {task.done()}")
 
         # Send the multiplicator to be drawn until crash
-        # transmitter_task = asyncio.create_task(continuously_transmit_mult(game.get_crash_event()))
-        # crash_task = asyncio.create_task(game.wait_for_crash())
-        logging.info("Gonna start tranmission of mult")
         await continuously_transmit_mult(game.get_crash_event())
 
         # await asyncio.gather(transmitter_task, crash_task)
@@ -106,8 +96,6 @@ async def loop():
             game.wait_for_crash(),
         )
 
-        logging.info("Both tasks completed")
-
         await manager.broadcast_lobby(
             {
                 "type": "state",
@@ -115,7 +103,6 @@ async def loop():
                 "cash_vaults": game.get_cash_vaults(game_handler.players),
             }
         )
-        logging.info("waited for game crash event message")
         # We update the player history (bids, gains and multipliers)
         game.update_players_history()
         game.reset_game()

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -1,45 +1,47 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-from typing import Union
 import json
-from threading import Thread, Event, Lock
+from contextlib import asynccontextmanager
 import asyncio
-import time
 from pymongo import MongoClient
 
 from crash.game_handler import GameHandler
-from crash.utils import run_async_in_thread
+import logging
 
-app = FastAPI()
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.DEBUG,
+    datefmt="%H:%M:%S",
+)
 
 
 class ConnectionManager:
     def __init__(self):
-        self.mutex = Lock()
+        self.mutex = asyncio.Lock()
         self.active_connections: list[WebSocket] = []
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
-        with self.mutex:
+        async with self.mutex:
             self.active_connections.append(websocket)
 
-    def disconnect(self, websocket: WebSocket):
-        with self.mutex:
+    async def disconnect(self, websocket: WebSocket):
+        async with self.mutex:
             self.active_connections.remove(websocket)
 
     async def send_personal_message_lobby(self, message: dict, websocket: WebSocket):
-        with self.mutex:
+        async with self.mutex:
             await websocket.send_text(json.dumps(message))
 
     async def broadcast_lobby(self, message: dict):
-        with self.mutex:
+        async with self.mutex:
             for connection in self.active_connections:
                 await connection.send_text(json.dumps(message))
 
 
 # Connect to Mongo, get db and the player collection
-mongo_client = MongoClient("db", 27017, serverSelectionTimeoutMS=2000)
-db = mongo_client.crash
-players_collection = db.players
+# mongo_client = MongoClient("db", 27017, serverSelectionTimeoutMS=2000)
+# db = mongo_client.crash
+# players_collection = db.players
 
 manager = ConnectionManager()
 
@@ -48,31 +50,37 @@ game = game_handler.get_game()
 
 # Event from threading library to get event driven approach :D
 # The event is set in the websocket handler for when a player joins
-player_join_event = Event()
+player_join_event = asyncio.Event()
 
 
-async def continuously_transmit_mult(stop_event: Event):
-    while True:
+async def continuously_transmit_mult(stop_event: asyncio.Event):
+    logging.info("Enter continuously_transmit_mult")
+    # for task in asyncio.all_tasks():
+    #     logging.info(f"[continuously_transmit_mult] Task: {task}, Coroutine: {task.get_coro().__name__}, Done: {task.done()}")
+
+    while not stop_event.is_set():
+        logging.info("Transmit")
         await manager.broadcast_lobby(
             {"type": "mult", "mult": game.get_multiplicator()}
         )
-        time.sleep(0.02)
-        if stop_event.is_set():
-            return
+        await asyncio.sleep(0.02)
 
 
 # Server loop
 async def loop():
+    logging.info("LOOP")
     while True:
+        logging.info("LOOP start")
         current_players = game_handler.players
-        # print(current_players)
+        # logging.info(current_players)
         # If there is no player we wait for one to save CPU cycles
         if len(current_players) == 0:
-            print("Waiting for players...")
-            player_join_event.wait()
+            logging.info("Waiting for players...")
+            await player_join_event.wait()
 
         # Start timer
-        estimated_start_time = game.start_pre_game_wait()
+        estimated_start_time = await game.start_pre_game_wait()
+        logging.info("waited for pre game wait")
         await manager.broadcast_lobby(
             {
                 "type": "state",
@@ -80,21 +88,30 @@ async def loop():
                 "estimated_start": estimated_start_time,
             }
         )
-        game.wait_for_game_start()
+        await game.wait_for_game_start()
+        logging.info("waited for game start")
 
         # Start the game
-        game.start_game()
+        await game.start_game()
         await manager.broadcast_lobby({"type": "state", "state": "playing"})
+        logging.info("waited for game playing event message")
+        # for task in asyncio.all_tasks():
+        #     logging.info(f"[main] Task: {task}, Coroutine: {task.get_coro().__name__}, Done: {task.done()}")
 
-        # Send the multiplicator to be drawn
-        sender = Thread(
-            target=run_async_in_thread,
-            args=(lambda: continuously_transmit_mult(game.get_crash_event()),),
+        # Send the multiplicator to be drawn until crash
+        # transmitter_task = asyncio.create_task(continuously_transmit_mult(game.get_crash_event()))
+        # crash_task = asyncio.create_task(game.wait_for_crash())
+        logging.info("Gonna start tranmission of mult")
+        await continuously_transmit_mult(game.get_crash_event())
+
+        # await asyncio.gather(transmitter_task, crash_task)
+        await asyncio.gather(
+            asyncio.shield(continuously_transmit_mult(game.get_crash_event())),
+            game.wait_for_crash(),
         )
-        sender.start()
 
-        # Play until crash
-        game.wait_for_crash()
+        logging.info("Both tasks completed")
+
         await manager.broadcast_lobby(
             {
                 "type": "state",
@@ -102,6 +119,7 @@ async def loop():
                 "cash_vaults": game.get_cash_vaults(game_handler.players),
             }
         )
+        logging.info("waited for game crash event message")
         # We update the player history (bids, gains and multipliers)
         game.update_players_history()
         game.reset_game()
@@ -117,8 +135,14 @@ def run_async_loop():
     event_loop.run_until_complete(loop())
 
 
-thread = Thread(target=run_async_loop, daemon=True)
-thread.start()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    event_loop = asyncio.get_event_loop()
+    asyncio.ensure_future(loop(), loop=event_loop)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 """
 ws: expected json
@@ -145,7 +169,7 @@ async def websocket_endpoint(websocket: WebSocket):
         while True:
 
             data = await websocket.receive_text()
-            print(data)
+            logging.info(data)
             message = json.loads(data)
 
             if message["type"] == "join":
@@ -158,26 +182,26 @@ async def websocket_endpoint(websocket: WebSocket):
                 # Name will be google id string later
                 name = message["name"]
 
-                player_info = players_collection.find_one({"name": name})
+                player_info = None  # players_collection.find_one({"name": name})
                 # Check if player is in the db
                 if player_info == None:
                     # If not, we create their doc
                     cash = 1000
-                    player_id = players_collection.insert_one(
-                        {
-                            "name": name,
-                            "cash": cash,
-                            "bid_history": [],
-                            "gain_history": [],
-                            "mult_history": [],
-                        }
-                    )
+                    player_id = "hey"  # players_collection.insert_one(
+                    #     {
+                    #         "name": name,
+                    #         "cash": cash,
+                    #         "bid_history": [],
+                    #         "gain_history": [],
+                    #         "mult_history": [],
+                    #     }
+                    # )
                     print("Player added to db with id :", player_id)
 
                 else:
                     cash = player_info["cash"]
 
-                game_handler.join(websocket, name, cash)
+                await game_handler.join(websocket, name, cash)
 
                 # Broadcast the lobby state to everyone
                 await manager.broadcast_lobby(

--- a/backend/src/crash/player.py
+++ b/backend/src/crash/player.py
@@ -1,13 +1,24 @@
 from crash.records import Cashout
-from typing import Optional
+from typing import Optional, List, Any, Dict, Type
 
 
 class PlayingPlayer:
-    def __init__(self, name: str):
+    def __init__(
+        self,
+        name: str,
+        cash: int = 1000,
+        bid_history: List[int] = None,
+        gain_history: List[int] = None,
+        mult_history: List[float] = None,
+    ):
         self.name = name
         self.bid_value: int = -1
         self.has_bid: bool = False
+        self.cash = cash
         self.cashout_record: Optional[Cashout] = None
+        self.bid_history: List[int] = bid_history or []
+        self.gain_history: List[int] = gain_history or []
+        self.mult_history: List[float] = mult_history or []
 
     def cashout(self, mult: float) -> Cashout:
         assert (
@@ -23,11 +34,21 @@ class PlayingPlayer:
             return True
         return False
 
+    def reset_game(self):
+        self.cashout_record = None
+        self.has_bid = False
+        self.bid_value = -1
 
-class Player:
-    def __init__(self, name: str, cash: int):
-        self.name = name
-        self.cash = cash
-        self.bid_history = []
-        self.gain_history = []
-        self.mult_history = []
+    def to_db_entry(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "cash": self.cash,
+            "bid_history": self.bid_history,
+            "gain_history": self.gain_history,
+            "mult_history": self.mult_history,
+        }
+
+    @staticmethod
+    def from_db_entry(db_entry: Dict[str, Any]) -> Type["PlayingPlayer"]:
+        del db_entry["_id"]
+        return PlayingPlayer(**db_entry)

--- a/backend/src/crash/utils.py
+++ b/backend/src/crash/utils.py
@@ -1,5 +1,9 @@
-from asyncio import Event, sleep
+from asyncio import Event, sleep, create_task
 import logging
+
+
+async def background_sleep_and_go(duration: int, event: Event):
+    create_task(sleep_and_go(duration, event))
 
 
 async def sleep_and_go(duration: int, event: Event):

--- a/backend/src/crash/utils.py
+++ b/backend/src/crash/utils.py
@@ -1,20 +1,10 @@
-import time
-import asyncio
-from threading import Event, Thread
+from asyncio import Event, sleep
+import logging
 
 
-def sleep_and_go(duration: int, event: Event):
+async def sleep_and_go(duration: int, event: Event):
     """Sleep for `duration` s, then fire the `event`"""
-
-    def _thread_func():
-        time.sleep(duration)
-        event.set()
-
-    Thread(target=_thread_func).start()
-
-
-def run_async_in_thread(async_func):
-    # Create a new event loop in the thread and run the async function
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(async_func())
+    logging.info("Start sleep")
+    await sleep(duration)
+    logging.info("end sleep")
+    event.set()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,11 +47,13 @@ export default function App() {
             setTimeout(() => {
                 const now = new Date();
                 const remainingTimeMs = countDownVal.estimatedStart - now;
-                setCountDownVal({
-                    estimatedStart: countDownVal.estimatedStart,
-                    // We want to countdown 100ms at a time
-                    remainingTime: remainingTimeMs / 100,
-                });
+                if (remainingTimeMs > 0) {
+                    setCountDownVal({
+                        estimatedStart: countDownVal.estimatedStart,
+                        // We want to countdown 100ms at a time
+                        remainingTime: remainingTimeMs / 100,
+                    });
+                }
                 // 95ms timeout cause we tend to get late scheduled
                 // The remaining time doesn't get offset since we're still recomputing each time
             }, 95);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,7 +68,7 @@ export default function App() {
             console.log(`ws opened, sending ${email}`);
             ws.current.send(JSON.stringify({
                 "type": "join",
-                "name": getRandomName(),
+                "name": email,
             }));
         };
         ws.current.onclose = () => console.log("ws closed");


### PR DESCRIPTION
## Asyncio
Replace threaded logic with asyncio. 
Everything now runs on the same thread in a concurrent but not parallel fashion.

## DB
Load all data from db and instantiate a `PlayingPlayer` with it. Use a single instance of player in all places; get rid of other types representing player. The historical data (bids, mults, cashouts) are all read and re-written at each transaction.