### PR TITLE
Frontend fixes and improvements

### DIFF
--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -18,8 +18,8 @@ class GameHandler:
     def __init__(
         self,
         name: str = "New Lobby",
-        average: float = 5,
-        standard_deviation: float = 5,
+        average: float = 30,
+        standard_deviation: float = 10,
         minimum_time: float = 3,
         starting_multiplicator: float = 0.75,
         multiplicator_coef: float = 0.1,

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -177,7 +177,7 @@ class Game:
     def get_bids(self, current_players: dict) -> Dict[str, int]:
         bids_dict = {}
         for ws in current_players:
-            if ws in self.players:
+            if ws in self.players and self.players[ws].has_bid:
                 bids_dict[current_players[ws].name] = self.players[ws].bid_value
 
         return bids_dict

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -18,8 +18,8 @@ class GameHandler:
     def __init__(
         self,
         name: str = "New Lobby",
-        average: float = 30,
-        standard_deviation: float = 10,
+        average: float = 5,
+        standard_deviation: float = 5,
         minimum_time: float = 3,
         starting_multiplicator: float = 0.75,
         multiplicator_coef: float = 0.1,

--- a/backend/src/crash/game_handler.py
+++ b/backend/src/crash/game_handler.py
@@ -193,10 +193,8 @@ class Game:
         }
 
     # States management
-    def is_waiting(self) -> bool:
-        return (
-            time.time() - self.waiting_initial_time
-        ) < GAME_WAIT_TIME_S  # 10 seconds wait for now
+    def is_playing(self) -> bool:
+        return self.ongoing
 
     def reset_waiting_time(self):
         self.waiting_initial_time = time.time()

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -188,7 +188,7 @@ async def websocket_endpoint(websocket: WebSocket):
                         ],
                         "cash_vaults": game.get_cash_vaults(game_handler.players),
                         "bids": game.get_bids(game_handler.players),
-                        "state": "waiting" if game.is_waiting() else "playing",
+                        "state": "playing" if game.is_playing() else "waiting",
                     }
                 )
 

--- a/backend/src/crash/main.py
+++ b/backend/src/crash/main.py
@@ -210,6 +210,7 @@ async def websocket_endpoint(websocket: WebSocket):
                             "amount": amount,
                             "bids": game.get_bids(game_handler.players),
                             "cash_vaults": game.get_cash_vaults(game_handler.players),
+                            "cashouts": game.get_cashouts(),
                         }
                     )
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -99,6 +99,10 @@ export default function App() {
                     setPlayers(event.lobby);
                     setCashVaults(event.cash_vaults);
                     break;
+                case "leave":
+                    setPlayers(event.lobby);
+                    setCashVaults(event.cash_vaults);
+                    break;
                 case "state":
                     setGameState(event.state);
                     if (event.state == "playing") {
@@ -207,7 +211,7 @@ export default function App() {
                     </div>
 
                     {/* Right Panel */}
-                    <div className="flex flex-col grow space-y-4">
+                    <div className="flex flex-col grow space-y-4 min-w-96">
                         <Lobby players={players} />
                         <CashValuesTable title="Cash vaults" mapping={cashVaults} sorted={true} />
                         <CashoutTable rows={cashoutData} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -227,7 +227,6 @@ export default function App() {
                         {Object.keys(cashoutData.previousRound).length > 0 &&
                             <CashoutTable title="Previous round" rows={cashoutData.previousRound} active={false} />
                         }
-                        <h1>{gameState}</h1>
                     </div>
 
                     {/* Errors */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,8 +76,8 @@ export default function App() {
     }
 
     let myCashout = null;
-    if (email in cashoutData) {
-        myCashout = cashoutData[email];
+    if (email in cashoutData.currentRound) {
+        myCashout = cashoutData.currentRound[email];
     }
 
     useEffect(() => {
@@ -96,6 +96,7 @@ export default function App() {
                 case "join":
                     setPlayers(event.lobby);
                     setCashVaults(event.cash_vaults);
+                    setGameState(event.state);
                     break;
                 case "leave":
                     setPlayers(event.lobby);
@@ -207,9 +208,7 @@ export default function App() {
                     <div className="flex-row w-1/5">
                         <p className="text-amber-600 font-bold text-lg">Balance: <span className="animate-pulse">{myCash}</span></p>
                         {(gameState == GameStates.PLAYING || gameState == GameStates.CASHED_OUT) &&
-                            <>
-                                <Cashout bidAmount={myBid} hasCashedOut={gameState == GameStates.CASHED_OUT && myCashout != null} cashOutObj={myCashout} cashoutCallback={cashout} />
-                            </>
+                            <Cashout bidAmount={myBid} hasCashedOut={gameState == GameStates.CASHED_OUT && myCashout != null} cashOutObj={myCashout} cashoutCallback={cashout} />
                         }
                         {gameState == GameStates.WAITING &&
                             <Bidding bidFunc={makeBid} bid={myBid} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -126,10 +126,9 @@ export default function App() {
                 case "bid":
                     setBids(event.bids);
                     setCashVaults(event.cash_vaults);
-                    const localCopy = event.cashouts;
                     setCashoutData((prev) => ({
                         ...prev,
-                        currentRound: localCopy,
+                        currentRound: event.cashouts,
                     }));
                     break;
                 case "error":

--- a/frontend/src/Cashout.jsx
+++ b/frontend/src/Cashout.jsx
@@ -1,5 +1,7 @@
 export default function Cashout({ bidAmount, hasCashedOut, cashOutObj, cashoutCallback }) {
     const playing = bidAmount > 0;
+    const playingActiveButtonStyle = "bg-green-500 hover:bg-green-400 hover:shadow-xl active:bg-green-600";
+    const playingInactiveButtonStyle = "bg-green-700";
 
     return (
         <div className="flex flex-col items-center bg-gray-800 p-4 rounded-lg shadow-md space-y-4 space-x-4">
@@ -17,10 +19,14 @@ export default function Cashout({ bidAmount, hasCashedOut, cashOutObj, cashoutCa
             }
             <button
                 onClick={() => cashoutCallback()}
-                disabled={!playing}
-                className={"inline-block px-6 py-3 text-gray-900 font-bold text-lg rounded-lg shadow-lg transition duration-300 " + (playing ? "bg-green-500 hover:bg-green-400 hover:shadow-xl active:bg-green-600" : "bg-gray-700")}
+                disabled={!playing || hasCashedOut}
+                className={"inline-block px-6 py-3 text-gray-900 font-bold text-lg rounded-lg shadow-lg transition duration-300 " + (playing ? (hasCashedOut ? playingInactiveButtonStyle : playingActiveButtonStyle) : "bg-gray-700")}
             >
-                Cashout
+                {hasCashedOut ?
+                    "Cashed out"
+                    :
+                    "Cashout"
+                }
             </button>
         </div>
     )

--- a/frontend/src/Cashout.jsx
+++ b/frontend/src/Cashout.jsx
@@ -1,9 +1,6 @@
 export default function Cashout({ bidAmount, hasCashedOut, cashOutObj, cashoutCallback }) {
     const playing = bidAmount > 0;
 
-    console.log(hasCashedOut);
-    console.log(cashOutObj);
-
     return (
         <div className="flex flex-col items-center bg-gray-800 p-4 rounded-lg shadow-md space-y-4 space-x-4">
             <p className="text-lg font-semibold text-gray-200">Cashout</p>

--- a/frontend/src/CashoutTable.jsx
+++ b/frontend/src/CashoutTable.jsx
@@ -13,11 +13,11 @@ const COLUMN_ORDERING = ["bid", "mult", "gain"];
  * }
  * @returns React component to display the data
  */
-export default function CashoutTable({ rows }) {
+export default function CashoutTable({ title, rows, active }) {
     const data = Object.keys(rows).map(name => [name, ...COLUMN_ORDERING.map(col => rows[name][col])]);
     return (
         <div>
-            <h2>Cashout</h2>
+            <p className="text-grey-200 font-bold text-lg">{title}</p>
             <table className="w-full bg-gray-800 rounded-lg shadow-md overflow-hidden">
                 <thead>
                     <tr className="bg-gray-700 text-gray-200">
@@ -28,18 +28,34 @@ export default function CashoutTable({ rows }) {
                     </tr>
                 </thead>
                 <tbody>
-                    {data.map(([name, bid, mult, gain], index) => (
-                        <tr
-                            key={index}
-                            className={`text-gray-300 ${index % 2 === 0 ? "bg-gray-700" : "bg-gray-800"
-                                }`}
-                        >
-                            <td className="px-4 py-2">{name}</td>
-                            <td className="px-4 py-2">{bid}</td>
-                            <td className="px-4 py-2">{mult}</td>
-                            <td className="px-4 py-2">{gain}</td>
-                        </tr>
-                    ))}
+                    {data.map(([name, bid, mult, gain], index) => {
+                        let textColor;
+                        if (mult < 0) {
+                            if (active) {
+                                textColor = "text-gray-300";
+                                mult = "";
+                                gain = "";
+                            } else {
+                                textColor = "text-red-500";
+                                mult = 0;
+                                gain = -bid;
+                            }
+                        } else {
+                            textColor = "text-green-500";
+                        }
+                        return (
+                            <tr
+                                key={index}
+                                className={`${textColor} ${index % 2 === 0 ? "bg-gray-700" : "bg-gray-800"
+                                    }`}
+                            >
+                                <td className="px-4 py-2 text-center">{name}</td>
+                                <td className="px-4 py-2 text-center">{bid}</td>
+                                <td className="px-4 py-2 text-center">{mult}</td>
+                                <td className="px-4 py-2 text-center">{gain}</td>
+                            </tr>
+                        )
+                    })}
                 </tbody>
             </table>
         </div>

--- a/frontend/src/CrashCurve.jsx
+++ b/frontend/src/CrashCurve.jsx
@@ -103,7 +103,7 @@ export default function CrashCurve({ points: mults, countdown }) {
 
 
     return (
-        <canvas id="curve-canvas" ref={canvasRef} width="1100px" height="480px" className="rounded-lg shadow-lg bg-gray-800">
+        <canvas id="curve-canvas" ref={canvasRef} width="700px" height="480px" className="rounded-lg shadow-lg bg-gray-800">
         </canvas>
     )
 }

--- a/frontend/src/auth/Login.jsx
+++ b/frontend/src/auth/Login.jsx
@@ -30,6 +30,10 @@ export default function Login() {
         setToken(userCred.user.accessToken);
     }
 
+    function signInAsUser(jwt) {
+        setToken(jwt);
+    }
+
     return (
         <div>
             {token ?
@@ -38,6 +42,7 @@ export default function Login() {
                 <div>
                     <h1>Please login</h1> <br />
                     <button onClick={launchAuth}>Login with Firebase</button>
+                    <button onClick={() => signInAsUser("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InVzZXJBIn0.gZ7MUilFmj3_MfX644CFCe3E0efLzY6-GO6JXi374Mk")}>Login as userA</button>
                 </div>
             }
         </div>

--- a/frontend/src/auth/Login.jsx
+++ b/frontend/src/auth/Login.jsx
@@ -42,7 +42,9 @@ export default function Login() {
                 <div>
                     <h1>Please login</h1> <br />
                     <button onClick={launchAuth}>Login with Firebase</button>
-                    <button onClick={() => signInAsUser("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InVzZXJBIn0.gZ7MUilFmj3_MfX644CFCe3E0efLzY6-GO6JXi374Mk")}>Login as userA</button>
+                    {import.meta.env.VITE_ENV == "dev" &&
+                        <button onClick={() => signInAsUser("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InVzZXJBIn0.gZ7MUilFmj3_MfX644CFCe3E0efLzY6-GO6JXi374Mk")}>Login as userA</button>
+                    }
                 </div>
             }
         </div>


### PR DESCRIPTION
* Resolved frontend multiplayer bug where a player bidding would prevent other players from bidding
* Store previous round cashout data and display it
* Color code bids for their different states: in progress / loss / gain
* Remove bidding view: 
  * All bids are now shown in the cashout modal
  * As a result, cashouts are now also sent on bid / in the bid event
* Update cashout button to show "Cashed out" and set colours to show its disabled state
* Properly ingest state on player join
  * Also fix state querying in client code on server side (`is_waiting ()`-> `is_playing()`)
* Remove current state from frontend
* Titles, sizing

### UI improvements, cashout history from previous round
![image](https://github.com/user-attachments/assets/577ec4b9-264c-496c-975c-6b5104438e28)

### Multiple players cashing out successfully in the previous round
![image](https://github.com/user-attachments/assets/a2128926-de86-4500-9754-a39278c4b2db)

